### PR TITLE
nvim-yarp の使用をやめる

### DIFF
--- a/init.vim
+++ b/init.vim
@@ -26,7 +26,6 @@ if dein#load_state('~/.local/share/dein')
   " Add or remove your plugins here:
   " 補完
   call dein#add('Shougo/deoplete.nvim')
-  call dein#add('roxma/nvim-yarp')
   call dein#add('cohama/lexima.vim')
   call dein#add('tyru/caw.vim')
   call dein#add('tpope/vim-surround')
@@ -70,9 +69,6 @@ syntax enable
 
 " deoplete
 " ---
-" Neovim リモートプラグイン機能の代わりに nvim-yarp を使用する
-let g:deoplete#enable_yarp = 1
-
 " deoplete を開始する
 call deoplete#enable()
 


### PR DESCRIPTION
エラーの原因が根本的に解決したので、nvim-yarp の使用をやめる。